### PR TITLE
♻️ refactor: LCP, CLS 개선 및 img 태그 alt 추가로 접근성 개선

### DIFF
--- a/src/component/MovieCard.tsx
+++ b/src/component/MovieCard.tsx
@@ -114,7 +114,7 @@ export default function MovieCard({
           <div className="relative overflow-hidden rounded-[10px]">
             <img
               className="w-full h-[344px] object-cover"
-              src={`https://image.tmdb.org/t/p/w500${poster_path}`}
+              src={`https://image.tmdb.org/t/p/w342${poster_path}`}
               alt={title}
             />
             <iframe

--- a/src/component/MovieRow.tsx
+++ b/src/component/MovieRow.tsx
@@ -44,7 +44,7 @@ export default function MovieRow({
   return (
     <div className="mb-10 min-h-[250px]" ref={ref}>
       <h2 className="text-xl md:text-2xl font-bold text-white mb-4">{title}</h2>
-      <div className="flex overflow-x-auto hide-scrollbar space-x-2">
+      <ul className="flex overflow-x-auto hide-scrollbar space-x-2">
         {/* 이미 들어온 영화 카드 */}
         {movies.map((movie) => (
           <MovieCard
@@ -59,7 +59,7 @@ export default function MovieRow({
         {Array.from({ length: skeletonsToShow }).map((_, idx) => (
           <SkeletonMovieCard key={`skeleton-${idx}`} />
         ))}
-      </div>
+      </ul>
     </div>
   )
 }

--- a/src/component/MovieSlider.tsx
+++ b/src/component/MovieSlider.tsx
@@ -43,16 +43,22 @@ export default function MovieSlider({
       >
         {slideMovieData.map(({ id, backdrop_path, title, overview }, index) => (
           <div
-            className="w-full flex-shrink-0 h-[500px] object-cover relative cursor-pointer"
+            className="w-full flex-shrink-0 h-[600px] object-cover relative cursor-pointer"
             key={backdrop_path}
             onClick={() => navigate(`/movie/${id}`)}
           >
-            {!loaded[index] && <SkeletonSlider />}
-            <img
-              className="absolute inset-0 w-full h-full object-cover z-0"
-              src={`https://image.tmdb.org/t/p/w1280${backdrop_path}`}
-              onLoad={() => handleImageLoad(index)}
-            />
+            <div className="absolute inset-0">
+              {!loaded[index] && <SkeletonSlider />}
+              <img
+                className="absolute inset-0 w-full h-full object-cover z-0"
+                src={`https://image.tmdb.org/t/p/w1280${backdrop_path}`}
+                alt={`${title}의 슬라이드 이미지`}
+                onLoad={() => handleImageLoad(index)}
+                width={1280}
+                height={600}
+                fetchPriority={index === 0 ? 'high' : 'auto'} // 첫 번째 이미지 우선 fetch(LCP 개선)
+              />
+            </div>
             <div className="absolute inset-0 bg-black/30 z-10" />
             <div className="relative z-20 max-w-[1200px] mx-auto px-4 h-full flex flex-col justify-end pb-5">
               <h1 className="text-3xl md:text-4xl font-bold max-w-2xl">

--- a/src/component/NavbarPcView.tsx
+++ b/src/component/NavbarPcView.tsx
@@ -32,7 +32,13 @@ export default function NavbarPcView({
           className="text-white text-2xl font-bold tracking-tight cursor-pointer"
           onClick={() => navigate(`/`)}
         >
-          <img src={mainLogo} alt="mainLogo" className="h-20" />
+          <img
+            src={mainLogo}
+            alt="mainLogo"
+            className="h-20"
+            width={80}
+            height={80}
+          />
         </button>
 
         <div className="flex-1 hidden md:flex items-center justify-center px-4">

--- a/src/component/ShareButtonGroup.tsx
+++ b/src/component/ShareButtonGroup.tsx
@@ -92,12 +92,20 @@ export default function ShareButtonGroup({
   }
   return (
     <div className={cn(kakaoButton({ mobile: touchEnabled }), className)}>
-      <IoIosShareAlt size={30} onClick={handleWebShare} />
+      <IoIosShareAlt
+        size={30}
+        onClick={handleWebShare}
+        className="text-white"
+      />
       <button
         aria-label={`${title}영화 카카오 공유 버튼`}
         onClick={handleKakaoShare}
       >
-        <img src={kakaoShareButton} className="cursor-pointer h-7" />
+        <img
+          src={kakaoShareButton}
+          alt={`${title} 카카오 공유 버튼 이미지`}
+          className="cursor-pointer h-7"
+        />
       </button>
     </div>
   )

--- a/src/page/MainPage.tsx
+++ b/src/page/MainPage.tsx
@@ -35,7 +35,7 @@ export default function MainPage() {
   }, [])
 
   return (
-    <div className="bg-black min-h-screen px-5 md:px-10 py-10 md:py-20">
+    <div className="bg-black min-h-screen">
       <MovieSlider slideMovieData={slideMovieData} />
       <div className="mt-20 space-y-10">
         {movieRows.map(({ title, category, immediate }) => (


### PR DESCRIPTION
## 개선내용
### LCP 개선
- 슬라이드의 첫번째 이미지 우선 fetch 적용
```
<img
    className="absolute inset-0 w-full h-full object-cover z-0"
    src={`https://image.tmdb.org/t/p/w1280${backdrop_path}`}
    alt={`${title}의 슬라이드 이미지`}
    onLoad={() => handleImageLoad(index)}
    width={1280}
    height={600}
    fetchPriority={index === 0 ? 'high' : 'auto'} // 첫 번째 이미지 우선 fetch(LCP 개선)
  />
```
- 영화 카드의 fetch 이미지 조정

<기존>
```
https://image.tmdb.org/t/p/w500${poster_path}        
```
<수정>
```
https://image.tmdb.org/t/p/w342${poster_path}        
```

### CLS 개선
- `img` 태그의 `width` 속성과 `height` 속성을 적용하여 렌더링 전 배치 위치 고정하여 UI 흔들림 개선.

### 접근성 개선
- `img` 태그 alt 속성 적용

## 개선 결과



| 개선 전 | 개선 후 |
|---------|---------|
| <img height="300" src="https://github.com/user-attachments/assets/ac3f7008-79c0-4b3d-b116-71dccd9fb65a" /> | <img height="300" src="https://github.com/user-attachments/assets/6dc71948-fd06-4c39-8a40-b149a0fdb8e9" /> |


